### PR TITLE
2パターンの表示レイアウト

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,16 @@ import React from "react";
 import { BrowserRouter, Route } from "react-router-dom";
 import './App.css';
 import { Home } from "./component/Home"
-import { EarringImg } from "./component/EarringImg";
+import { EarringImg_Quilted } from "./component/EarringImg_Quilted";
+import { EarringImg_Masonry } from "./component/EarringImg_Masonry";
 import { Routes } from "react-router";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/EarringImg" element={<EarringImg />} />
+        <Route path="/EarringImg_Quilted" element={<EarringImg_Quilted />} />
+        <Route path="/EarringImg_Masonry" element={<EarringImg_Masonry />} />
         <Route path="/" element={<Home />} />
         {/* <Route exact path="/" component={Home} /> */}
         {/* <Redirect to="/" /> */}

--- a/src/component/EarringImg_Masonry.tsx
+++ b/src/component/EarringImg_Masonry.tsx
@@ -3,13 +3,13 @@ import Box from '@mui/material/Box';
 import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import ImageListItemBar from '@mui/material/ImageListItemBar';
-import { itemData } from './ItemData';
+import { itemData_Masonry } from './ItemData_Masonry';
 
-export const  EarringImg = () => {
+export const  EarringImg_Masonry = () => {
     return (
         <Box sx={{ width: '80%', height: 1, overflowY: 'scroll',  margin: 'auto'}}>
             <ImageList variant="masonry" cols={3} gap={8}>
-                {itemData.map((item) => (
+                {itemData_Masonry.map((item) => (
                     <ImageListItem key={item.img}>
                         <img
                             src={`${item.img}?w=248&fit=crop&auto=format`}

--- a/src/component/EarringImg_Quilted.tsx
+++ b/src/component/EarringImg_Quilted.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+import ImageListItemBar from '@mui/material/ImageListItemBar';
+import { itemData_Quilted } from './ItemData_Quilted';
+
+const srcset = (image:string, size:any, rows = 1, cols = 1) => {
+    return {
+      src: `${image}?w=${size * cols}&h=${size * rows}&fit=crop&auto=format`,
+      srcSet: `${image}?w=${size * cols}&h=${
+        size * rows
+      }&fit=crop&auto=format&dpr=2 2x`,
+    };
+  }
+
+export const  EarringImg_Quilted = () => {
+    return (
+        <Box sx={{ width: '60%', height: 1, overflowY: 'scroll',  margin: 'auto'}}>
+        <ImageList
+            variant="quilted"
+            cols={4}
+        >
+        {itemData_Quilted.map((item) => (
+          <ImageListItem key={item.img} cols={item.cols || 1} rows={item.rows || 1}>
+            <img
+              {...srcset(item.img, 300, item.rows, item.cols)}
+              alt={item.title}
+              loading="lazy"
+            />
+            <ImageListItemBar
+                sx={{
+                background:
+                    'linear-gradient(to top, rgba(225,225,225,0.7) 0%, ' +
+                    'rgba(225,225,225,0.4) 70%, rgba(225,225,225,0) 100%)',
+                }}
+                title={item.title}
+                position="bottom"
+                />
+          </ImageListItem>
+        ))}
+      </ImageList>
+      </Box>
+    );
+}

--- a/src/component/Home.tsx
+++ b/src/component/Home.tsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
-import { EarringImg } from "./EarringImg";
+import { EarringImg_Masonry } from './EarringImg_Masonry';
+import { EarringImg_Quilted } from './EarringImg_Quilted';
 
 export const Home = () => {
     return(
         <>
-        <Link to="/EarringImg">WorkList</Link>
+        <div><Link to="/EarringImg_Masonry">EarringImg_Masonry</Link></div>
+        <div><Link to="/EarringImg_Quilted">EarringImg_Quilted</Link></div>
         </>
     )
 }

--- a/src/component/ItemData_Masonry.ts
+++ b/src/component/ItemData_Masonry.ts
@@ -1,0 +1,85 @@
+import hook_Blue from './Image/hook_Blue.jpg';
+import hook_BlueSkyblueWhite from './Image/hook_BlueSkyblueWhite.jpg';
+import hook_BlueWhite from './Image/hook_BlueWhite.jpg';
+import hook_GreenWhite from './Image/hook_GreenWhite.jpg';
+import hook_OrangeYellowWhite from './Image/hook_OrangeYellowWhite.jpg';
+import hook_PinkRed from './Image/hook_PinkRed.jpg';
+import hook_Red from './Image/hook_Red.jpg';
+import hook_RedOrangeYellow from './Image/hook_RedOrangeYellow.jpg';
+import hook_VioletRedPink from './Image/hook_VioletRedPink.jpg';
+import stud_Blue from './Image/stud_Blue.jpg';
+import stud_BlueWhite from './Image/stud_BlueWhite.jpg';
+import stud_Green from './Image/stud_Green.jpg';
+import stud_Orange from './Image/stud_Orange.jpg';
+import stud_OrangeGreenYellow from './Image/stud_OrangeGreenYellow.jpg';
+import stud_RedWhite from './Image/stud_RedWhite.jpg';
+import stud_VioletPinkWhite from './Image/stud_VioletPinkWhite.jpg';
+
+export const itemData_Masonry = [
+    {
+        img: hook_Blue,
+        title: 'hook_blue',
+    },
+    {
+        img: hook_BlueSkyblueWhite,
+        title: 'hook_blue-skyblue-white',
+    },
+    {
+        img: hook_BlueWhite,
+        title: 'hook_blue-white',
+    },
+    {
+        img: hook_GreenWhite,
+        title: 'hook_green-white',
+    },
+    {
+        img: hook_OrangeYellowWhite,
+        title: 'hook_orange-yellow-white',
+    },
+    {
+        img: hook_PinkRed,
+        title: 'hook_PinkRed',
+    },
+    {
+        img: hook_Red,
+        title: 'hook_Red',
+    },
+    {
+        img: hook_RedOrangeYellow,
+        title: 'hook_RedOrangeYellow',
+    },
+    {
+        img: hook_VioletRedPink,
+        title: 'hook_VioletRedPink',
+    },
+    {
+        img: stud_Blue,
+        title: 'stud_Blue',
+    },
+    {
+        img: stud_BlueWhite,
+        title: 'stud_BlueWhite',
+    },
+    {
+        img: stud_Green,
+        title: 'stud_Green',
+    },
+    {
+        img: stud_Orange,
+        title: 'stud_Orange',
+    },
+    {
+        img: stud_OrangeGreenYellow,
+        title: 'stud_OrangeGreenYellow',
+    },
+    {
+        img: stud_RedWhite,
+        title: 'stud_RedWhite',
+    },
+    {
+        img: stud_VioletPinkWhite,
+        title: 'stud_VioletPinkWhite',
+    },
+]
+
+// }

--- a/src/component/ItemData_Quilted.ts
+++ b/src/component/ItemData_Quilted.ts
@@ -15,10 +15,12 @@ import stud_OrangeGreenYellow from './Image/stud_OrangeGreenYellow.jpg';
 import stud_RedWhite from './Image/stud_RedWhite.jpg';
 import stud_VioletPinkWhite from './Image/stud_VioletPinkWhite.jpg';
 
-export const itemData = [
+export const itemData_Quilted = [
     {
         img: hook_Blue,
         title: 'hook_blue',
+        rows: 2,
+        cols: 2,
     },
     {
         img: hook_BlueSkyblueWhite,
@@ -31,14 +33,18 @@ export const itemData = [
     {
         img: hook_GreenWhite,
         title: 'hook_green-white',
+        cols: 2,
     },
     {
         img: hook_OrangeYellowWhite,
         title: 'hook_orange-yellow-white',
+        cols: 2,
     },
     {
         img: hook_PinkRed,
         title: 'hook_PinkRed',
+        rows: 2,
+        cols: 2,
     },
     {
         img: hook_Red,
@@ -51,6 +57,8 @@ export const itemData = [
     {
         img: hook_VioletRedPink,
         title: 'hook_VioletRedPink',
+        rows: 2,
+        cols: 2,
     },
     {
         img: stud_Blue,
@@ -63,23 +71,25 @@ export const itemData = [
     {
         img: stud_Green,
         title: 'stud_Green',
+        cols: 2,
     },
     {
         img: stud_Orange,
         title: 'stud_Orange',
+        cols: 2,
     },
     {
-        img: stud_OrangeGreenYellow,
-        title: 'stud_OrangeGreenYellow',
+        img: stud_VioletPinkWhite,
+        title: 'stud_VioletPinkWhite',
+        rows: 2,
+        cols: 2,
     },
     {
         img: stud_RedWhite,
         title: 'stud_RedWhite',
     },
     {
-        img: stud_VioletPinkWhite,
-        title: 'stud_VioletPinkWhite',
+        img: stud_OrangeGreenYellow,
+        title: 'stud_OrangeGreenYellow',
     },
 ]
-
-// }


### PR DESCRIPTION
## やったこと
* Material uiのImageListを用いた2種類のレイアウトを作成。

1．Masonry image list
<img width="640" alt="image" src="https://user-images.githubusercontent.com/81846197/149941658-2a59b6c9-d0d6-422e-b173-d32b5e05d3ed.png">

2．Quilted image list
<img width="640" alt="image" src="https://user-images.githubusercontent.com/81846197/149941776-2ce143bd-5f5b-42d2-98ea-982eea264e2d.png">
