### PR TITLE
作品表示画面のレイアウト

### DIFF
--- a/src/component/Flowers.tsx
+++ b/src/component/Flowers.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useState } from "react";
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import { IconButton } from '@mui/material';
+import { useStyles } from './FlowersStyle';
+import { itemData_Masonry } from './ItemData_Masonry';
+
+export const Flowers = () => {
+    const classes = useStyles();
+
+    return(
+        <Box className={classes.box}>
+            <h1>3D Flowers</h1>
+            <Grid container className={classes.container}>
+                {itemData_Masonry.map((item) => (
+                    <Grid item className={classes.item} key={item.img}>
+                        <img src={item.img} />
+                        <IconButton 
+                            style={{position: "absolute",
+                                    bottom:58,
+                                    right:10,
+                                    color: "rgba(189, 189, 189, 0.80)"}} >
+                                <FullscreenIcon />
+                        </IconButton>
+                        <p>{item.title} </p>
+                    </Grid>
+                ))}
+            </Grid>
+
+        </Box>
+    );
+}

--- a/src/component/FlowersStyle.tsx
+++ b/src/component/FlowersStyle.tsx
@@ -1,0 +1,40 @@
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+
+export const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        box: {
+            width: '80vw',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            "& h1": {
+                textAlign: 'center',
+                color: '#666A71',
+                fontSize: '3em',
+                fontFamily: 'cursive',
+                padding: '0.5em'
+            }
+        },
+        container:{
+            gap: '4em',
+            justifyContent: 'center',
+            padding: '5% 0',
+        },
+        item:{
+            position: 'relative',
+            textAlign: 'center',
+            "& img": {
+                width: '10em',
+                height: '12em',
+                objectFit: 'cover',
+                border: '0.2em solid rgba(69, 71, 81, 0.16)',
+                padding: '0.4em',
+                backgroundColor: '#FFFFFF'
+            },
+            "& p": {
+                fontFamily: 'cursive',
+                fontSize: '0.8em',
+                color: '#BDBDBD'
+            }
+        },        
+    })
+)


### PR DESCRIPTION
## やったこと
* ピアスや花（ここでは花の予定）の作品一覧を展示するレイアウトを実装。
* Figmaで作成したシンプルなデザイン。
* Gridを使って配置した。
![messageImage_1644391389130](https://user-images.githubusercontent.com/81846197/153142455-d76a7354-c6f0-4972-8c93-de668e38af43.jpeg)

## メモ
* どのGridやコンテンツにどのcssを書けば思うように実装できるかに時間がかかった。
* Gridなどのフレームワークについての理解が必要。

* のちにmodal機能を付ける予定。（そのために拡大アイコンを写真の右下に付けた。）
